### PR TITLE
MNT: add aarch64/ppc64le to 0.26.1

### DIFF
--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
@@ -31,3 +31,15 @@ zip_keys:
   - cdt_name
 - - python
   - numpy
+build_platform:
+- linux-64
+CMAKE_CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static
+CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static
+build_platform:
+- linux-64
+CMAKE_CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static
+CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,12 @@ outputs:
     script: install-py.sh  # [unix]
     script: install-py.bat  # [win]
     build:
+      ignore_run_exports:
+        - python  # [build_platform != target_platform]
       run_exports:
         - {{ pin_subpackage('quil', max_pin='x.x') }}
+      missing_dso_whitelist:
+        - '*/ld64.so.2'  # [ppc64le]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "quil" %}
-{% set version = "0.27.0" %}
+{% set version = "0.26.1" %}
 
-{% set py_version = "0.11.0" %}
-{% set cli_version = "0.4.0" %}
+{% set py_version = "0.10.1" %}
+{% set cli_version = "0.3.1" %}
 
 package:
   name: quil-split
@@ -10,17 +10,17 @@ package:
 
 source:
   - url: https://github.com/rigetti/quil-rs/archive/refs/tags/quil-rs/v{{ version }}.tar.gz
-    sha256: 617ee83f244d106f519721422c43e623a5ad5b0f141b991e61c16ee673d7bd0d
+    sha256: 4181b6746ce629d03430dfbad1a6fef45f9814d43882528d23e3d4d7257a2efc
     patches:
       - fix-syrupy-dependent-test.patch
 
   - url: https://github.com/rigetti/quil-rs/archive/refs/tags/quil-py/v{{ py_version }}.tar.gz
-    sha256: db48b015a841469e46a2886f7c58483ea9a6d317d7d6e3fdbe9871afed96e5d7
+    sha256: 302227a478a56738bba2837c06889f93ccc7c60808455978b0a52e86300925f8
     folder: verify-quil-py
     patches:
       - fix-syrupy-dependent-test.patch
   - url: https://github.com/rigetti/quil-rs/archive/refs/tags/quil-cli/v{{ cli_version }}.tar.gz
-    sha256: 230c9d47d97de296bbb4fdfc22b29b777e724ded42ebd6530bc20b5dc1835539
+    sha256: 3b2044485cd0cd6f089b396d089ec985aaf2e6e52a444578f237e822318a5fde
     folder: verify-quil-cli
     patches:
       - fix-syrupy-dependent-test.patch


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
