### PR TITLE
FIX: ppc64le missing DSO. ignore python exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
       - fix-syrupy-dependent-test.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,12 @@ outputs:
     script: install-py.sh  # [unix]
     script: install-py.bat  # [win]
     build:
+      ignore_run_exports:
+        - python  # [build_platform != target_platform]
       run_exports:
         - {{ pin_subpackage('quil', max_pin='x.x') }}
+      missing_dso_whitelist:
+        - '*/ld64.so.2'  # [ppc64le]
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
